### PR TITLE
Add custom 404 page for better user experience

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <title>404 | BLENDER BOTS</title>
+        <link rel="stylesheet" href="src/404.css" />
+    </head>
+    <body>
+        <div class="content">
+            <h1>404</h1>
+            <p>No page found</p>
+            <a href="/">< Go back</a>
+        </div>
+    </body>
+</html>

--- a/src/404.css
+++ b/src/404.css
@@ -1,0 +1,28 @@
+body {
+    background-color: black;
+    color: white;
+    text-align: center;
+    font-family: arial;
+    height: 100vh;
+    margin: 0px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+h1 {
+    width: 100%;
+    font-size: 5em;
+    font-family: monospace;
+}
+p {
+    width: 100%;
+    font-size: 18px;
+}
+a {
+    color: white;
+    text-decoration: none;
+    transition: 0.2s;
+}
+a:hover {
+    color: yellow;
+}


### PR DESCRIPTION
fixes #25

# what did I change

I added a custom 404 page (`404.html`) with matching styles (`src/404.css`) to replace the default GitHub Pages 404. The page includes a message, navigation link back to the main page, and styling consistent with the site's theme.

# why did I change it

As #25 explains, the site didn't have a custom 404 page, so users who navigate to a non-existent URL see a generic GitHub Pages error with no branding or way back to the site. This change provides a branded, helpful 404 experience.

# UI changes

Before:
**exempt**

After:
**exempt**

# checklist

 - [X] I explained what and why with 2 sentences minimum for both sections
 - [ ] I showed UI changes before and after photos
 - [X] Changes are small
 - [X] Bug Free (if fixes an issue gives the issue fixed)
 - [X] Only one change made