### PR TITLE
Fix sponsor assets consolidation and Sponsor Us page

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,8 +66,8 @@
                     style="height: 25px; width: auto; margin-left: 15px"
                 />
                 <div class="sponsor-bar-inner">
-                    <a class="sponsor-bar-link" href="/src/sponserUs.html"
-                        >SPONSER US</a
+                    <a class="sponsor-bar-link" href="/src/sponsorUs.html"
+                        >SPONSOR US</a
                     >
                 </div>
             </div>
@@ -76,13 +76,26 @@
             <section class="about opacity-transition">
                 <h2>Who are we</h2>
                 <p>
-                    We are the Blender Bots, a high school robotics team competing in the FIRST Tech Challenge (FTC). Since 2016, we've been building robots and competing in FTC competitions. We are a major club that is the only STEM opportunity offered on campus. We strive not just to compete in competition but to teach useful skills and have our team veterans mentor recruits.
+                    We are the Blender Bots, a high school robotics team
+                    competing in the FIRST Tech Challenge (FTC). Since 2016,
+                    we've been building robots and competing in FTC
+                    competitions. We are a major club that is the only STEM
+                    opportunity offered on campus. We strive not just to compete
+                    in competition but to teach useful skills and have our team
+                    veterans mentor recruits.
                 </p>
             </section>
             <section class="info opacity-transition">
                 <h2>Rankings</h2>
                 <p>
-                    In the latest FTC competition (DECODE), we finished in the 90th percentile. This is all due to the work our team put into designing and ideating our robot (AIM). <a class="scouts-link" href="https://ftcscout.org/teams/12492">Click here to see our world rankings.</a>
+                    In the latest FTC competition (DECODE), we finished in the
+                    90th percentile. This is all due to the work our team put
+                    into designing and ideating our robot (AIM).
+                    <a
+                        class="scouts-link"
+                        href="https://ftcscout.org/teams/12492"
+                        >Click here to see our world rankings.</a
+                    >
                 </p>
                 <br />
             </section>
@@ -223,7 +236,15 @@
                     <div class="outreach-text">
                         <h2 class="" data-text="OutReach">Outreach</h2>
                         <p>
-                            This year, we set up several fundraisers partnering with restaurants such as Mendocino Farms, Panda Express, and Shake Shack. We also spread the word about our club and raised money by selling snacks at school events like cultural night, 8th-grade night, and reached out and had informational meetings at the start of the school year. We were very successful this year and had over 10 brand new members, greatly expanding the team.
+                            This year, we set up several fundraisers partnering
+                            with restaurants such as Mendocino Farms, Panda
+                            Express, and Shake Shack. We also spread the word
+                            about our club and raised money by selling snacks at
+                            school events like cultural night, 8th-grade night,
+                            and reached out and had informational meetings at
+                            the start of the school year. We were very
+                            successful this year and had over 10 brand new
+                            members, greatly expanding the team.
                         </p>
                     </div>
                 </div>
@@ -239,7 +260,14 @@
                             Gracious Professionalism
                         </h2>
                         <p>
-                            Gracious Professionalism is a key point of FTC, which is to not just compete against other teams but to respect and help them. We've shown gracious professionalism over the season by giving people replacement parts and even helping with debugging code. Among the people we helped are RMS (Redwood Middle School) Overdrive, Wolfbotics, and Inquiry Robotics.
+                            Gracious Professionalism is a key point of FTC,
+                            which is to not just compete against other teams but
+                            to respect and help them. We've shown gracious
+                            professionalism over the season by giving people
+                            replacement parts and even helping with debugging
+                            code. Among the people we helped are RMS (Redwood
+                            Middle School) Overdrive, Wolfbotics, and Inquiry
+                            Robotics.
                         </p>
                     </div>
                 </div>
@@ -253,7 +281,15 @@
                     <div class="outreach-text">
                         <h2 class="" data-text="STEM">STEM</h2>
                         <p>
-                            We are the only STEM opportunity on campus. This means any students who want to do STEM would have to be on the Blender Bots team. This causes challenges due to large demand and limited spots. To fix this, we plan on making a JV team; however, for this, we need more sponsors and a larger space. As we are a club, we will not refuse any student who wants to join, but they may have to just shadow our veterans for a period of time until a spot opens up.
+                            We are the only STEM opportunity on campus. This
+                            means any students who want to do STEM would have to
+                            be on the Blender Bots team. This causes challenges
+                            due to large demand and limited spots. To fix this,
+                            we plan on making a JV team; however, for this, we
+                            need more sponsors and a larger space. As we are a
+                            club, we will not refuse any student who wants to
+                            join, but they may have to just shadow our veterans
+                            for a period of time until a spot opens up.
                         </p>
                     </div>
                 </div>
@@ -276,11 +312,11 @@
                 </div>
             </section>
         </div>
-        <footer role="footer">
+        <footer>
             <div>
                 <ul>
                     <li><a href="mailto:">contact us</a></li>
-                    <li><a href="src/sponserUs.html">sponser us</a></li>
+                    <li><a href="src/sponsorUs.html">sponsor us</a></li>
                     <li>
                         <a href="https://www.instagram.com/blenderbots/"
                             ><svg

--- a/src/sponsorUs.css
+++ b/src/sponsorUs.css
@@ -69,7 +69,7 @@ body::before {
     text-shadow: 2px 2px 2px var(--neon-cyan);
     font-family: inter;
     font-weight: 800;
-    content: "SPONSER US";
+    content: "SPONSOR US";
 }
 
 h1,

--- a/src/sponsorUs.html
+++ b/src/sponsorUs.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <title>Sponser | Blender Bots</title>
+        <title>Sponsor | Blender Bots</title>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
         <link
@@ -25,7 +25,7 @@
             type="image/x-icon"
             href="../src/photos/logo/favicon_io/favicon.ico"
         />
-        <link rel="stylesheet" href="sponserUs.css" />
+        <link rel="stylesheet" href="sponsorUs.css" />
         <!-- Open Graph -->
         <meta property="og:title" content="Sponsor Us | Blender Bots" />
         <meta
@@ -35,7 +35,7 @@
         <meta property="og:type" content="website" />
         <meta
             property="og:url"
-            content="https://blenderbots12492.github.io/src/sponserUs.html"
+            content="https://blenderbots12492.github.io/src/sponsorUs.html"
         />
         <meta
             property="og:image"
@@ -78,23 +78,40 @@
             >
         </nav>
 
-        <h2>Why sponser us</h2>
+        <h2>Why sponsor us</h2>
         <p>
-            The Blender Bots are a unique and dedicated team. We persevere despite the many challenges we've encountered, such as financial issues, having few mentors from the industry, and being a title one public school. This means we have to make international efforts to secure funding for ourselves. We are proud to be a student-run team. We've held on to our objectives and continued to be passionate in our individual roles.
+            The Blender Bots are a unique and dedicated team. We persevere
+            despite the many challenges we've encountered, such as financial
+            issues, having few mentors from the industry, and being a title one
+            public school. This means we have to make international efforts to
+            secure funding for ourselves. We are proud to be a student-run team.
+            We've held on to our objectives and continued to be passionate in
+            our individual roles.
         </p>
         <p>
-            We have drastically improved this year, and even people like Principal Nguyen have noted our achievements. Principal Nguyen says, "In recognition of remarkable growth, as a program and a team, the Blender Bots of Del Mar High School, more than doubled their membership, guided new members through training, and delivered their strongest competition season to date" at a board meeting. This demonstrates how people have been noticing us, which has inspired more people to join our club, and we need more financial support now to best serve our team.
+            We have drastically improved this year, and even people like
+            Principal Nguyen have noted our achievements. Principal Nguyen says,
+            "In recognition of remarkable growth, as a program and a team, the
+            Blender Bots of Del Mar High School, more than doubled their
+            membership, guided new members through training, and delivered their
+            strongest competition season to date" at a board meeting. This
+            demonstrates how people have been noticing us, which has inspired
+            more people to join our club, and we need more financial support now
+            to best serve our team.
         </p>
         <p>
-            We are only getting better with time and are teaching our teammates how to work in a STEM environment, but there is only so much we can do with our current resources. Please donate to help us be the best team we can be.
+            We are only getting better with time and are teaching our teammates
+            how to work in a STEM environment, but there is only so much we can
+            do with our current resources. Please donate to help us be the best
+            team we can be.
         </p>
-        <h2>How to sponser us</h2>
+        <h2>How to sponsor us</h2>
         <p>Contact us at <a href="">____@____.com</a> and thank you so much</p>
         <footer role="footer">
             <div>
                 <ul>
                     <li><a>contact us</a></li>
-                    <li><a href="sponserUs.html">sponser us</a></li>
+                    <li><a href="sponsorUs.html">sponsor us</a></li>
                     <li>
                         <a
                             ><svg


### PR DESCRIPTION
Fixes #42, #33

# What did I change

I added a dedicated Sponsor Us page and supporting assets. I renamed the misspelled sponsor files and updated the site navigation to point to the Sponsor Us page.

# Why did I change it

I changed these assets to fix broken sponsor links and to align file names with the site's conventions. The new Sponsor Us page makes sponsorship outreach clearer and more accessible for potential sponsors.

# UI changes

Before: Sponsor Us did not exist and sponsorship assets were misspelled, causing broken UX.
After: Sponsor Us page added at src/sponsorUs.html with styling from sponsorUs.css, and main index link updated to point to the Sponsor Us page.

# Checklist
- [x] I explained what and why with 2 sentences minimum for both sections
- [x] I showed UI changes before and after photos
- [x] Changes are small
- [x] Bug Free (if fixes an issue gives the issue fixed)
- [ ] Only one change made
