### PR TITLE
Joseph/mobile paralax

### DIFF
--- a/src/baseline.css
+++ b/src/baseline.css
@@ -65,6 +65,12 @@ html {
 @media (min-width: 1024px) {
     /* no override for baseline on large screens */
 }
+/* Mobile: disable fixed background to prevent iOS zoom bug */
+@media (max-width: 768px) {
+    .parallax {
+        background-attachment: scroll;
+    }
+}
 html {
     scroll-behavior: smooth;
 }

--- a/src/baseline.css
+++ b/src/baseline.css
@@ -39,6 +39,7 @@ html {
 }
 .sponsor-bar > a > img.nav-logo,
 .sponsor-bar > img.nav-logo {
+    margin-top: calc(var(--nav-height) - (var(--nav-logo-height) / 1.25));
     height: var(--nav-logo-height) !important;
     width: auto;
 }

--- a/src/bot-page.css
+++ b/src/bot-page.css
@@ -107,6 +107,13 @@ body {
     line-height: 1.75;
 }
 
+/* Mobile: disable fixed background to prevent iOS zoom bug */
+@media (max-width: 768px) {
+    .parallax {
+        background-attachment: scroll;
+    }
+}
+
 @media (min-width: 980px) {
     .robot-summary-grid {
         grid-template-columns: minmax(0, 1.35fr) minmax(280px, 360px);


### PR DESCRIPTION
Fixes #21

**What did I change**

Fixed the mobile parallax background appearing zoomed in on iOS Safari by overriding `background-attachment: fixed` to `background-attachment: scroll` on mobile viewports. Added a `@media (max-width: 768px)` rule to `baseline.css` and `bot-page.css` to disable the fixed background behavior only on small screens.

**Why did I change it**

On iOS Safari, `background-attachment: fixed` combined with `background-size: cover` causes the browser to size the image against the full viewport instead of the element itself, making it appear massively zoomed in within the parallax container. Desktop parallax is preserved since the fix is scoped to mobile widths only.

**UI changes**

*Before:* 
<img width="585" height="1266" alt="IMG_1037" src="https://github.com/user-attachments/assets/90f2c3b5-0844-4dc1-8572-aee7f2ec66cf" />

*After:*
<img width="585" height="1266" alt="IMG_1036" src="https://github.com/user-attachments/assets/fe0c22be-96b8-42ec-82a8-033ad7760abb" />

**Checklist**

- [x] I explained what and why with 2 sentences minimum for both sections
- [x] I showed UI changes before and after photos
- [x] Changes are small
- [x] Bug Free (fixes #21)
- [ ] Only one change made