### PR TITLE
capatlized nav bar links

### DIFF
--- a/src/header.html
+++ b/src/header.html
@@ -8,10 +8,10 @@
             <img src="/src/photos/logo/Banner.png" alt="The Blender Bots" class="nav-logo" />
         </a>
         <div>
-            <a href="/index.html#robots">robots</a>
-            <a href="/index.html#sponsors">sponsors</a>
-            <a href="/index.html#outreach">outreach</a>
-            <a href="/index.html#contact">contact us</a>
+            <a href="/index.html#robots">Robots</a>
+            <a href="/index.html#sponsors">Sponsors</a>
+            <a href="/index.html#outreach">Outreach</a>
+            <a href="/index.html#contact">Contact Us</a>
         </div>
         <div class="sponsor-bar-inner">
             <button class="cta-btn shared-cta" type="button" aria-label="Sponsorship CTA"></button>


### PR DESCRIPTION
Fixes #65 
# What did I change
I capitalized all of the links in the NavBar. This includes the capitalization of robots, sponsors, outreach, and contact us on the NavBar 
# Why did I change it
It looked unofficial and diminished our professionalism as a team. It made us look like lesser beings compared to other FTC teams and I could not bear to see this uncapitalized text.
# UI changes
Before: 
<img width="1365" height="651" alt="Screenshot 2026-05-27 12 58 50" src="https://github.com/user-attachments/assets/728b798e-e3fd-44d0-8831-131ecee5a3b9" />
After:
<img width="1365" height="651" alt="Screenshot 2026-05-27 12 58 00" src="https://github.com/user-attachments/assets/0f68e5ad-8efb-4a47-84d0-457f91f1907d" />

# Checklist

*It is ok if not all boxes are checked, but it will be denied if no boxes are checked*
- [x] I explained what and why with 2 sentences minimum for both sections
- [x] I showed UI changes before and after photos
- [x] Changes are small
- [x] Bug Free (if fixes an issue gives the issue fixed)
- [x] Only one change made
