### PR TITLE
delayed rescroll by 100ms

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,14 +75,18 @@
                         }
                     });
             })();
+            //wait for page load
             window.addEventListener("load", () => {
-                if (window.location.hash) {
+                //delay by 100ms
+                setTimeout(()=>{
+                    //rescroll to header
+                    if (window.location.hash) {
                     const target = document.querySelector(window.location.hash);
                     if (target) {
                         // Re-trigger the scroll once the banner/JS content is ready
                         target.scrollIntoView();
                     }
-                }
+                }}, 100);
             });
         </script>
         <div class="content">


### PR DESCRIPTION
Fixes #68 
# What did I change
In the scroll code, I added a delay using setTimeout for 100ms. This means after the page loads, it'll wait another 100ms to let images finish loading.

# Why did I change it
Caused users to scroll to the wrong spot when coming from a different page. This could potentially confuse the users and hinder their navigation through the website.
> NOTE:
>See PR #54 for additional details. 

# UI changes
Before:

https://github.com/user-attachments/assets/b4e4c351-2bd0-4f28-b931-97cbb69ed35e

After:

[Screen recording 2026-05-28 11.22.15 AM.webm](https://github.com/user-attachments/assets/aebca05f-1dde-40dc-9226-24c7a273ca1c)

# Checklist

- [X] I explained what and why with 2 sentences minimum for both sections
- [X] I showed UI changes before and after photos
- [X] Changes are small
- [X] Bug Free (if fixes an issue gives the issue fixed)
- [X] Only one change made
