### PR TITLE
Added link to maps

### DIFF
--- a/index.html
+++ b/index.html
@@ -327,7 +327,7 @@
                     </div>
                     <div class="contact-card">
                         <h3>School Address</h3>
-                        <a href="https://www.google.com/maps/place/Del+Mar+High+School/@37.3039885,-121.9321802,17z/data=!3m1!4b1!4m6!3m5!1s0x808e34c986146e67:0x1bb7b6bfdf636c30!8m2!3d37.3039885!4d-121.9295999!16zL20vMDYyMHl6?entry=ttu&g_ep=EgoyMDI2MDUyNy4wIKXMDSoASAFQAw%3D%3D" target="_blank">1224 Del Mar Ave, San Jose, CA 95128</p>
+                        <a href="https://www.google.com/maps/place/1224+Del+Mar+Ave,+San+Jose,+CA+95128/@37.3053772,-121.9286302,51m/data=!3m1!1e3!4m6!3m5!1s0x808e34cbbb496e75:0x187c0ea1d33e9135!8m2!3d37.3054282!4d-121.9283924!16s%2Fg%2F11x8s96hvb?entry=ttu&g_ep=EgoyMDI2MDUyNy4wIKXMDSoASAFQAw%3D%3D" target="_blank">1224 Del Mar Ave, San Jose, CA 95128</p>
                     </div>
                 </div>
             </section>

--- a/index.html
+++ b/index.html
@@ -319,7 +319,7 @@
                 <div class="contact-grid">
                     <div class="contact-card">
                         <h3>Email</h3>
-                        <a href="mailto:team12492@gmail.com">team12492@gmail.com</a>
+                        <a href="mailto:team12492@gmail.com" target="_blank">team12492@gmail.com</a>
                     </div>
                     <div class="contact-card">
                         <h3>YouTube</h3>
@@ -327,7 +327,7 @@
                     </div>
                     <div class="contact-card">
                         <h3>School Address</h3>
-                        <p>1224 Del Mar Ave, San Jose, CA 95128</p>
+                        <a href="https://www.google.com/maps/place/Del+Mar+High+School/@37.3039885,-121.9321802,17z/data=!3m1!4b1!4m6!3m5!1s0x808e34c986146e67:0x1bb7b6bfdf636c30!8m2!3d37.3039885!4d-121.9295999!16zL20vMDYyMHl6?entry=ttu&g_ep=EgoyMDI2MDUyNy4wIKXMDSoASAFQAw%3D%3D" target="_blank">1224 Del Mar Ave, San Jose, CA 95128</p>
                     </div>
                 </div>
             </section>


### PR DESCRIPTION
# What did I change
I made it so when you click on the address in the contact us section, it brings you to Del Mar on Google maps. I made sure that it opens in a new tab in order to not close the blender bots tab.

# Why did I change it
It was a big problem with the user experience. If a user wanted to come visit our robotics team, they would have to highlight and copy and paste the address after opening maps in a new tab, this link allows the users to access our school's location with much haste.

# UI changes
Before:
[Screen recording 2026-05-29 12.44.00.webm](https://github.com/user-attachments/assets/a4ad49e1-1872-443d-95f0-6dbfc35b53d7)
After:
[Screen recording 2026-05-29 12.44.27.webm](https://github.com/user-attachments/assets/4476fdb0-c1c5-4889-99f6-2baf0bc8986c)


# Checklist

*It is ok if not all boxes are checked, but it will be denied if no boxes are checked*
- [x] I explained what and why with 2 sentences minimum for both sections
- [x] I showed UI changes before and after photos
- [x] Changes are small
- [x] Bug Free (if fixes an issue gives the issue fixed)
- [x] Only one change made
