### PR TITLE
changed 404.css URL in 404.html

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <title>404 | BLENDER BOTS</title>
-        <link rel="stylesheet" href="src/404.css" />
+        <link rel="stylesheet" href="/src/404.css" />
     </head>
     <body>
         <div class="content">


### PR DESCRIPTION
# What did I change
I added a / before the css URL in 404.html. This will take the root no matter where you are in the website.

# Why did I change it

Without this change the 404 page would be styled correctly. However when another slash was in the URL ex: ".com/test/test" the page would not get the css properly.

# UI changes

After:
<img width="1366" height="768" alt="Screenshot 2026-05-29 2 29 41 PM" src="https://github.com/user-attachments/assets/8b302a1d-9ca3-4f61-9dbb-830b01cd827a" />
Before:
<img width="1366" height="768" alt="Screenshot 2026-05-29 2 27 52 PM" src="https://github.com/user-attachments/assets/52f54f94-2880-44ee-a8aa-cff8ae5b2140" />

# Checklist

*It is ok if not all boxes are checked, but it will be denied if no boxes are checked*
- [X] I explained what and why with 2 sentences minimum for both sections
- [X] I showed UI changes before and after photos
- [X] Changes are small
- [X] Bug Free (if fixes an issue gives the issue fixed)
- [X] Only one change made
